### PR TITLE
RPC authentication examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To run the examples, you need to set up the environment variables. In the root o
 ACCOUNT_ID=near-api-tester.testnet // The account ID to use for the examples
 PRIVATE_KEY=ed25519:5gUStfPd... // The private key for the account
 SEED_PHRASE="goose card december immune flag ..." // The seed phrase for the account
+FASTNEAR_API_KEY=your_api_key_here // (Optional) FastNear RPC API key for authenticated requests
 ```
 
 These can be created using the [NEAR CLI](https://github.com/near/near-cli-rs)

--- a/near-api-js/examples/rpc-auth.ts
+++ b/near-api-js/examples/rpc-auth.ts
@@ -1,0 +1,19 @@
+import { JsonRpcProvider } from "near-api-js";
+import dotenv from "dotenv";
+
+dotenv.config();
+// Replace with your own API key, or set FASTNEAR_API_KEY in .env
+const apiKey = process.env.FASTNEAR_API_KEY || "1111111111111111111111111111111111111111111111111111111111111111";
+
+// Create a provider with API key authentication
+// The Bearer token header authenticates requests to avoid rate limiting
+const provider = new JsonRpcProvider({
+  url: "https://rpc.mainnet.fastnear.com",
+  headers: { Authorization: `Bearer ${apiKey}` },
+});
+
+console.log("Using authenticated FastNear RPC");
+
+// Query account state to verify the connection
+const accountState = await provider.viewAccount({ accountId: "near" });
+console.log(accountState);

--- a/near-api-js/package.json
+++ b/near-api-js/package.json
@@ -29,6 +29,7 @@
     "manual-sign": "tsx examples/manual-sign.ts",
     "meta": "tsx examples/meta.ts",
     "private-key-string": "tsx examples/keystore-options/private-key-string.ts",
+    "rpc-auth": "tsx examples/rpc-auth.ts",
     "rpc-failover": "tsx examples/rpc-failover.ts",
     "seat-price": "tsx examples/seat-price.ts",
     "seed-phrase": "tsx examples/keystore-options/seed-phrase.ts",

--- a/near-kit/examples/rpc-auth.js
+++ b/near-kit/examples/rpc-auth.js
@@ -1,0 +1,17 @@
+import { Near } from "near-kit";
+import dotenv from "dotenv";
+
+dotenv.config();
+// Replace with your own API key, or set FASTNEAR_API_KEY in .env
+const apiKey = process.env.FASTNEAR_API_KEY || "1111111111111111111111111111111111111111111111111111111111111111";
+
+// Authenticate via query parameter appended to the RPC URL
+const rpcUrl = `https://rpc.mainnet.fastnear.com?apiKey=${apiKey}`;
+
+const near = new Near({ network: "mainnet", rpcUrl });
+
+console.log("Using authenticated FastNear RPC");
+
+// Query account balance to verify the connection
+const balance = await near.getBalance("root.near");
+console.log(`Balance: ${balance} NEAR`);

--- a/near-kit/package.json
+++ b/near-kit/package.json
@@ -21,6 +21,7 @@
     "keys": "node examples/keys.js",
     "manual-sign": "node examples/manual-sign.js",
     "private-key-string": "node examples/keystore-options/private-key-string.js",
+    "rpc-auth": "node examples/rpc-auth.js",
     "rpc-failover": "node examples/rpc-failover.js",
     "seat-price": "node examples/seat-price.js",
     "seed-phrase": "node examples/keystore-options/seed-phrase.js",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,3 +30,7 @@ path = "examples/signer_options/keystore.rs"
 [[example]]
 name = "seed_phrase"
 path = "examples/signer_options/seed_phrase.rs"
+
+[[example]]
+name = "rpc_auth"
+path = "examples/rpc_auth.rs"

--- a/rust/examples/rpc_auth.rs
+++ b/rust/examples/rpc_auth.rs
@@ -1,0 +1,38 @@
+use near_api::{AccountId, NetworkConfig, RPCEndpoint, Tokens};
+
+#[tokio::main]
+async fn main() {
+    // Load .env from the repo root (one level up from the rust directory)
+    dotenv::from_filename("../.env").ok();
+
+    // Replace with your own API key, or set FASTNEAR_API_KEY in .env
+    let api_key = std::env::var("FASTNEAR_API_KEY")
+        .unwrap_or_else(|_| "1111111111111111111111111111111111111111111111111111111111111111".to_string());
+
+    // Authenticate via query parameter appended to the RPC URL
+    let rpc_url = format!("https://rpc.mainnet.fastnear.com?apiKey={}", api_key);
+
+    let my_rpc_endpoint = RPCEndpoint::new(rpc_url.parse().unwrap());
+    let network = NetworkConfig {
+        network_name: "mainnet".to_string(),
+        rpc_endpoints: vec![my_rpc_endpoint],
+        linkdrop_account_id: Some("near".parse().unwrap()),
+        near_social_db_contract_account_id: Some("social.near".parse().unwrap()),
+        faucet_url: None,
+        meta_transaction_relayer_url: None,
+        fastnear_url: None,
+        staking_pools_factory_account_id: Some("poolv1.near".parse().unwrap()),
+    };
+
+    println!("Using authenticated FastNear RPC");
+
+    // Query account balance to verify the connection
+    let account_id: AccountId = "root.near".parse().unwrap();
+    let near_balance = Tokens::account(account_id)
+        .near_balance()
+        .fetch_from(&network)
+        .await
+        .unwrap();
+
+    println!("{:?}", near_balance);
+}


### PR DESCRIPTION
Various RPC/API services are available for NEAR now, like Lava and FastNear.

I cannot speak for Lava, but it's likely similar in nature to FastNear. There are two ways to authenticate:

- URL param (`?apiKey=<api_key>`)
- Header for auth `Bearer` token

This pull request shows how to use this authentication and will likely help people understand how to build dApps and backend services that can connect for high throughput queries and transactions through NEAR RPCs.